### PR TITLE
Support systems without a vulkan icd path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub enum DecodeError {
     AppID,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DesktopEntry<'a> {
     pub appid: &'a str,
     pub groups: Groups<'a>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub enum DecodeError {
     AppID,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DesktopEntry<'a> {
     pub appid: &'a str,
     pub groups: Groups<'a>,


### PR DESCRIPTION
Hey!

This code was written to expect a $VULKAN_ICD_PATH to be defined - on my system (which doesn't have a discrete GPU), it wasn't, and without a discrete GPU I don't expect to have to define one. 

As such, I've moved the environment variable check to execute at runtime and produce a list of empty GPU paths. (We could also produce `None` here, but wrapping `Result` again seems bad).